### PR TITLE
modified qunit behavior

### DIFF
--- a/lib/js/qunit.js
+++ b/lib/js/qunit.js
@@ -20,7 +20,9 @@ window.addEventListener("load", function(){
     print(ansi.green + result.passed + " passed, " + ansi.none);
     print("Total " + result.total);
     puts("");
-    
-    Ichabod.exit();
+  };
+
+  QUnit.done = function() {
+      Ichabod.exit();
   };
 });


### PR DESCRIPTION
Hi maccman,

"ichbod" stops running after qunit has completed its first test case. I found out that qunit has another callback that is fired at the very end of the test suite: "Qunit.done". At least the versions I tested: QUnit 1.3.0pre and 1.4.0pre offer this feature. I modified your code to wait for this callback in order to stop ichabod.

I hope I did not introduce a bug by submitting this patch.

Thanks for your great module, I love to use it!

Regards, Wolfgang Kinkeldei
